### PR TITLE
Patch: Remove dependency yaml and use regex to get sail services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,13 +38,9 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.3|^8.0",
-        "symfony/yaml": "^6.0",
         "laravel/sail": "^1.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0"
-    },
-    "scripts": {
-        "lint": "vendor/bin/pint"
     }
 }


### PR DESCRIPTION
- Replace yaml with regex to get sail services
- Remove symfony/yaml dependency
